### PR TITLE
multiple compiling issues resolved

### DIFF
--- a/example00/main.cpp
+++ b/example00/main.cpp
@@ -92,8 +92,10 @@ int main() {
     queue.enqueueWriteBuffer(buffer_N, CL_TRUE, 0, sizeof(int),   N);
 
     // RUN ZE KERNEL
-    cl::KernelFunctor simple_add(cl::Kernel(program, "simple_add"), queue, cl::NullRange, cl::NDRange(10), cl::NullRange);
-    simple_add(buffer_A, buffer_B, buffer_C, buffer_N);
+    cl::Kernel simple_add(program, "simple_add"); 
+    simple_add.setArg(0, buffer_A);
+    simple_add.setArg(1, buffer_B);
+    simple_add.setArg(2, buffer_C);
 
     int C[n];
     // read result from GPU to here


### PR DESCRIPTION
1. from [here](https://stackoverflow.com/q/21738032/4999991) curly braces should be removed to solve the error:

> error: expected expression

2. from [here](https://stackoverflow.com/a/21739380/4999991) the error:

> error: too many arguments to function call, expected single argument '__x', have 2 arguments

should be resolved.

3. the error:

> error: no matching member function for call to 'build'

from the [cl::Program Class Reference](https://github.khronos.org/OpenCL-CLHPP/classcl_1_1_program.html) the `build` function requires `const vector< Device >` or `const char *options`